### PR TITLE
[13494] Galactic Gamble Ubuntu binary installation guide

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -20,5 +20,5 @@ Main features
    :hidden:
    :numbered: 5
 
-   /rst/installation/linux_installation
+   /rst/installation/installation_manual
    /rst/notes/notes

--- a/docs/rst/installation/installation_manual.rst
+++ b/docs/rst/installation/installation_manual.rst
@@ -6,6 +6,6 @@ Installation Manual
 This sections includes the Vulcanexus installation instructions for the Tier 1 supported platforms.
 
 .. toctree::
-    :maxdepth: 2
+    :maxdepth: 1
 
     linux_installation.rst

--- a/docs/rst/installation/installation_manual.rst
+++ b/docs/rst/installation/installation_manual.rst
@@ -1,0 +1,11 @@
+.. _installation_manual:
+
+Installation Manual
+===================
+
+This sections includes the Vulcanexus installation instructions for the Tier 1 supported platforms.
+
+.. toctree::
+    :maxdepth: 2
+
+    linux_installation.rst

--- a/docs/rst/installation/linux_installation.rst
+++ b/docs/rst/installation/linux_installation.rst
@@ -50,3 +50,17 @@ Base Install: basic installation without simulation tools, demos, and tutorials.
     sudo apt install vulcanexus-galactic-base
 
 There are other packages available. Please refer to the :ref:`main_features` section for more information.
+
+Environment setup
+-----------------
+
+In order to use the Vulcanexus installation, the environment must be set up sourcing the following file:
+
+.. code-block:: bash
+
+    source /opt/vulcanexus/galactic/setup.bash
+
+Next steps
+----------
+
+Please, refer to the Tutorials section to keep learning about Vulcanexus capabilities and features.

--- a/docs/rst/installation/linux_installation.rst
+++ b/docs/rst/installation/linux_installation.rst
@@ -5,18 +5,19 @@ Linux binary installation
 
 Debian packages for Vulcanexus Galactic Gamble are currently available for Ubuntu Focal.
 Please, start following the `Installation Guide for ROS 2 Galactic Geochelone <https://docs.ros.org/en/galactic/Installation/Ubuntu-Install-Debians.html>`_ setting the locale to support ``UTF-8`` (if necessary) and the ROS 2 apt repository.
-Before proceeding installing the ROS 2 packages, follow the steps below.
+Instead of proceeding with installing the ROS 2 packages, follow the steps below.
 
 Setup sources
 -------------
 
-First, enable the following required repository running the command:
+First, add the Qt 5.15 required repository running the commands:
 
 .. code-block:: bash
 
+    sudo apt install software-properties-common
     sudo add-apt-repository ppa:beineri/opt-qt-5.15.2-focal
 
-Next, authorize Vulcanexus GPG key with apt:
+Next, add Vulcanexus GPG key so apt can retrieve the packages:
 
 .. code-block:: bash
 
@@ -49,7 +50,7 @@ Base Install: basic installation without simulation tools, demos, and tutorials.
 
     sudo apt install vulcanexus-galactic-base
 
-There are other packages available. Please refer to the :ref:`main_features` section for more information.
+For other Vulcanexus packages, please refer to the :ref:`main_features` section for more information.
 
 Environment setup
 -----------------
@@ -59,6 +60,15 @@ In order to use the Vulcanexus installation, the environment must be set up sour
 .. code-block:: bash
 
     source /opt/vulcanexus/galactic/setup.bash
+
+Uninstall eProsima Vulcanexus packages
+--------------------------------------
+
+To uninstall Vulcanexus, it is enough to run the following command :
+
+.. code-block:: bash
+
+    sudo apt autoremove vulcanexus-galactic-desktop
 
 Next steps
 ----------

--- a/docs/rst/installation/linux_installation.rst
+++ b/docs/rst/installation/linux_installation.rst
@@ -31,7 +31,7 @@ Finally, add the eProsima Vulcanexus repository to your sources list:
 Install eProsima Vulcanexus packages
 ------------------------------------
 
-Remeber to update your apt repository caches after setting up the repositories:
+Remember to update your apt repository caches after setting up the repositories:
 
 .. code-block:: bash
 

--- a/docs/rst/installation/linux_installation.rst
+++ b/docs/rst/installation/linux_installation.rst
@@ -2,3 +2,51 @@
 
 Linux binary installation
 =========================
+
+Debian packages for Vulcanexus Galactic Gamble are currently available for Ubuntu Focal.
+Please, start following the `Installation Guide for ROS 2 Galactic Geochelone <https://docs.ros.org/en/galactic/Installation/Ubuntu-Install-Debians.html>`_ setting the locale to support ``UTF-8`` (if necessary) and the ROS 2 apt repository.
+Before proceeding installing the ROS 2 packages, follow the steps below.
+
+Setup sources
+-------------
+
+First, enable the following required repository running the command:
+
+.. code-block:: bash
+
+    sudo add-apt-repository ppa:beineri/opt-qt-5.15.2-focal
+
+Next, authorize Vulcanexus GPG key with apt:
+
+.. code-block:: bash
+
+    sudo curl -sSL https://raw.githubusercontent.com/eProsima/vulcanexus/master/vulcanexus.key -o /usr/share/keyrings/vulcanexus-archive-keyring.gpg
+
+Finally, add the eProsima Vulcanexus repository to your sources list:
+
+.. code-block:: bash
+
+    echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/vulcanexus-archive-keyring.gpg] TODO(URL) $(source /etc/os-release && echo $UBUNTU_CODENAME) main" | sudo tee /etc/apt/sources.list.d/vulcanexus.list > /dev/null
+
+Install eProsima Vulcanexus packages
+------------------------------------
+
+Remeber to update your apt repository caches after setting up the repositories:
+
+.. code-block:: bash
+
+    sudo apt update
+
+Desktop install (Recommended): includes all the simulation tools, demos, and tutorials.
+
+.. code-block:: bash
+
+    sudo apt install vulcanexus-galactic-desktop
+
+Base Install: basic installation without simulation tools, demos, and tutorials.
+
+.. code-block:: bash
+
+    sudo apt install vulcanexus-galactic-base
+
+There are other packages available. Please refer to :ref:`main_feature` for more information.

--- a/docs/rst/installation/linux_installation.rst
+++ b/docs/rst/installation/linux_installation.rst
@@ -49,4 +49,4 @@ Base Install: basic installation without simulation tools, demos, and tutorials.
 
     sudo apt install vulcanexus-galactic-base
 
-There are other packages available. Please refer to :ref:`main_feature` for more information.
+There are other packages available. Please refer to the :ref:`main_features` section for more information.

--- a/docs/rst/spelling_wordlist.txt
+++ b/docs/rst/spelling_wordlist.txt
@@ -1,2 +1,3 @@
+eProsima
 Vulcanexus
 vulcanexus


### PR DESCRIPTION
This PR adds the Ubuntu binary installation guide for Vulcanexus Galactic Gamble.

WIP: the repository URL has to be defined. These instructions has not been partially tested (GPG key not hosted in the repository yet and final repository URL pending)