### PR TITLE
Docker installation documentation [14403]

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -72,14 +72,17 @@ def select_css(html_css_dir):
     :param html_css_dir: The directory to save the CSS stylesheet.
     :return: Returns a list of CSS files to be imported.
     """
+    ret = ['_static/tabs.css']
     common_css = '_static/css/eprosima_rtd_theme.css'
     local_css = '_static/css/fiware_readthedocs.css'
     if download_css(html_css_dir):
         print('Applying common CSS style file: {}'.format(common_css))
-        return [common_css]
+        ret.append(common_css)
     else:
         print('Applying local CSS style file: {}'.format(local_css))
-        return [local_css]
+        ret.append(local_css)
+
+    return ret
 
 
 script_path = os.path.abspath(pathlib.Path(__file__).parent.absolute())
@@ -97,7 +100,12 @@ project_source_docs_dir = os.path.abspath('{}/rst'.format(script_path))
 # ones.
 extensions = [
     'sphinx.ext.todo',
+    'sphinx_tabs.tabs'
 ]
+
+sphinx_tabs_disable_css_loading = False
+sphinx_tabs_disable_tab_closing = True
+
 try:
     import sphinxcontrib.spelling  # noqa: F401
     extensions.append('sphinxcontrib.spelling')

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,7 +1,8 @@
 doc8==0.10.1
 docutils==0.16.0
 setuptools==59.4.0
-sphinx==4.3.1
 sphinx_rtd_theme==0.5.2
-sphinxcontrib.spelling==7.2.1
+sphinx-tabs==3.2.0
+sphinx==4.3.1
 sphinxcontrib-imagehelper==1.1.1
+sphinxcontrib.spelling==7.2.1

--- a/docs/rst/installation/docker.rst
+++ b/docs/rst/installation/docker.rst
@@ -1,0 +1,67 @@
+.. _docker_installation:
+
+Docker installation
+===================
+
+*Vulcanexus* offers the possibility of running from a containerized environment by providing a Docker image which contains *Vulcanexus*'s Desktop installation.
+This Docker image can be found in `Vulcanexus's Downloads <https://vulcanexus.org/download>`_.
+To run it, first install Docker:
+
+.. code-block:: bash
+
+    sudo apt install docker.io
+
+And then load the image with:
+
+.. code-block:: bash
+
+    docker load -i ubuntu-vulcanexus-galactic-desktop.tar
+
+*Vulcanexus* Docker image can be run with:
+
+.. tabs::
+
+    .. tab:: GUI support
+
+        .. code-block:: bash
+
+            xhost local:root
+            docker run \
+                -it \
+                --privileged \
+                -e DISPLAY=$DISPLAY \
+                -v /tmp/.X11-unix:/tmp/.X11-unix \
+                ubuntu-vulcanexus:galactic-desktop
+
+    .. tab:: CLI support
+
+        .. code-block:: bash
+
+            docker run -it ubuntu-vulcanexus:galactic-desktop
+
+To run more than one session within the same container, *Vulcanexus* installation must be sourced.
+Given a running container, you can open another session by:
+
+.. code-block:: bash
+
+    docker exec -it <running-container-id> bash
+
+Then, within the container, source the *Vulcanexus* installation with:
+
+.. code-block:: bash
+
+    source /opt/vulcanexus/galactic/setup.bash
+
+To verify that the sourcing was correct, run:
+
+.. code-block:: bash
+
+    echo $VULCANEXUS_HOME
+
+The output should be:
+
+.. code-block:: bash
+
+    /opt/vulcanexus/galactic
+
+Please refer to :ref:`vulcanexus_tutorials` to read about all the *Vulcanexus* possibilities and getting started with developing for *Vulcanexus*.

--- a/docs/rst/installation/installation_manual.rst
+++ b/docs/rst/installation/installation_manual.rst
@@ -10,3 +10,4 @@ This sections includes the Vulcanexus installation instructions for the Tier 1 s
 
     linux_binary_installation.rst
     linux_source_installation.rst
+    docker.rst


### PR DESCRIPTION
This PR adds a documentation section about using *Vulcanexus* Docker image.
Furthermore, it also adds tabs support for the documentation project.

Signed-off-by: Eduardo Ponz <eduardoponz@eprosima.com>