### PR TITLE
Vulcanexus 2.0.4

### DIFF
--- a/vulcanexus.repos
+++ b/vulcanexus.repos
@@ -66,7 +66,7 @@ repositories:
   eProsima/Vulcanexus-Base:
     type: git
     url: https://github.com/eProsima/vulcanexus.git
-    version: v2.0.3
+    version: v2.0.4
   ros2/ROSIDL-TypeSupport-FastRTPS:
     type: git
     url: https://github.com/ros2/rosidl_typesupport_fastrtps.git

--- a/vulcanexus.repos
+++ b/vulcanexus.repos
@@ -5,7 +5,7 @@ repositories:
     version: v1.0.0  
   eProsima/dev-utils:
     type: git
-    url: https://github.com/eProsima/DDS-Router.git
+    url: https://github.com/eProsima/dev-utils.git
     version: v0.1.0
   eProsima/Fast-CDR:
     type: git
@@ -50,7 +50,7 @@ repositories:
   eProsima/Micro-XRCE-DDS-Agent:
     type: git
     url: https://github.com/eProsima/Micro-XRCE-DDS-Agent
-    version: 2.2.1
+    version: v2.2.1
   eProsima/RMW-Fast-DDS:
     type: git
     url: https://github.com/eProsima/rmw_fastrtps.git
@@ -66,7 +66,7 @@ repositories:
   eProsima/Vulcanexus-Base:
     type: git
     url: https://github.com/eProsima/vulcanexus.git
-    version: 51756543ac2bf2ff01f355528dbbc01af63979cf
+    version: v2.0.3
   ros2/ROSIDL-TypeSupport-FastRTPS:
     type: git
     url: https://github.com/ros2/rosidl_typesupport_fastrtps.git

--- a/vulcanexus.repos
+++ b/vulcanexus.repos
@@ -2,31 +2,35 @@ repositories:
   eProsima/DDS-Router:
     type: git
     url: https://github.com/eProsima/DDS-Router.git
-    version: v0.4.0
+    version: v1.0.0  
+  eProsima/dev-utils:
+    type: git
+    url: https://github.com/eProsima/DDS-Router.git
+    version: v0.1.0
   eProsima/Fast-CDR:
     type: git
     url: https://github.com/eProsima/Fast-CDR.git
-    version: v1.0.24
+    version: v1.0.25
   eProsima/Fast-DDS:
     type: git
     url: https://github.com/eProsima/Fast-DDS.git
-    version: v2.7.1
+    version: v2.8.0
   eProsima/Fast-DDS-Gen:
     type: git
     url: https://github.com/eProsima/Fast-DDS-Gen.git
-    version: v2.1.3
+    version: v2.2.0
   eProsima/Fast-DDS-Monitor:
     type: git
     url: https://github.com/eProsima/Fast-DDS-monitor.git
-    version: v1.2.0
+    version: v1.2.1
   eProsima/Fast-DDS-Python:
     type: git
     url: https://github.com/eProsima/Fast-DDS-python.git
-    version: v1.1.0
+    version: v1.2.0
   eProsima/Fast-DDS-Statistics-Backend:
     type: git
     url: https://github.com/eProsima/Fast-DDS-statistics-backend.git
-    version: v0.7.0
+    version: v0.7.1
   eProsima/Foonathan-Memory-Vendor:
     type: git
     url: https://github.com/eProsima/foonathan_memory_vendor.git
@@ -34,7 +38,7 @@ repositories:
   eProsima/Micro-ROS-Agent:
     type: git
     url: https://github.com/micro-ROS/micro-ROS-Agent.git
-    version: 3.0.3
+    version: 3.0.4
   eProsima/Micro-ROS-Msgs:
     type: git
     url: https://github.com/micro-ROS/micro_ros_msgs.git
@@ -42,11 +46,11 @@ repositories:
   eProsima/Micro-ROS-Setup:
     type: git
     url: https://github.com/micro-ROS/micro_ros_setup.git
-    version: 3.1.0
+    version: 3.1.2
   eProsima/Micro-XRCE-DDS-Agent:
     type: git
     url: https://github.com/eProsima/Micro-XRCE-DDS-Agent
-    version: v2.2.0
+    version: 2.2.1
   eProsima/RMW-Fast-DDS:
     type: git
     url: https://github.com/eProsima/rmw_fastrtps.git
@@ -54,7 +58,7 @@ repositories:
   eProsima/Shapes-Demo:
     type: git
     url: https://github.com/eProsima/ShapesDemo.git
-    version: v2.7.1
+    version: v2.8.0
   eProsima/Shapes-Demo-TypeSupport:
     type: git
     url: https://github.com/eProsima/ShapesDemo-TypeSupport.git
@@ -62,8 +66,8 @@ repositories:
   eProsima/Vulcanexus-Base:
     type: git
     url: https://github.com/eProsima/vulcanexus.git
-    version: v2.0.3
+    version: 51756543ac2bf2ff01f355528dbbc01af63979cf
   ros2/ROSIDL-TypeSupport-FastRTPS:
     type: git
     url: https://github.com/ros2/rosidl_typesupport_fastrtps.git
-    version: 2.2.0
+    version: 2.4.0


### PR DESCRIPTION
  * Added Dev-utils package version 0.1.0
  * Updated Fast DDS to 2.8.0
  * Updated Fast CDR to 1.0.25
  * Updated Fast DDS-Gen to 2.2.0
  * Updated Fast DDS Python to 1.2.0
  * Updated Fast DDS Monitor to 1.2.1
  * Updated Fast DDS Statistics Backend to 0.7.1
  * Updated DDS Router to 1.0.0
  * Updated Micro ROS Agent to 3.0.4
  * Updated Micro Ros Setup to 3.1.2
  * Updated Shapes Demo to 2.8.0

Signed-off-by: Javier Santiago <javiersantiago@eprosima.com>