### PR TITLE
[Fix] Change turtlesim code package name

### DIFF
--- a/code/turtlesim/CMakeLists.txt
+++ b/code/turtlesim/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.5)
-project(turtlesim)
+project(docs_turtlesim)
 
 if(NOT CMAKE_CXX_STANDARD)
   set(CMAKE_CXX_STANDARD 14)
@@ -18,13 +18,13 @@ rosidl_generate_interfaces(${PROJECT_NAME}
 
 rosidl_get_typesupport_target(cpp_typesupport_target "${PROJECT_NAME}" "rosidl_typesupport_cpp")
 
-add_executable(turtlesim_square_move src/SquareMove.cpp)
+add_executable(square_move src/SquareMove.cpp)
 
-ament_target_dependencies(turtlesim_square_move "ament_index_cpp" "geometry_msgs" "rclcpp" "std_msgs" "std_srvs")
+ament_target_dependencies(square_move "ament_index_cpp" "geometry_msgs" "rclcpp" "std_msgs" "std_srvs")
 
-target_link_libraries(turtlesim_square_move "${cpp_typesupport_target}")
+target_link_libraries(square_move "${cpp_typesupport_target}")
 
-install(TARGETS turtlesim_square_move
+install(TARGETS square_move
   DESTINATION lib/${PROJECT_NAME})
 
 ament_package()

--- a/code/turtlesim/CMakeLists.txt
+++ b/code/turtlesim/CMakeLists.txt
@@ -12,19 +12,15 @@ find_package(rclcpp REQUIRED)
 find_package(rosidl_default_generators REQUIRED)
 find_package(std_msgs REQUIRED)
 find_package(std_srvs REQUIRED)
+find_package(turtlesim REQUIRED)
 
-rosidl_generate_interfaces(${PROJECT_NAME}
-  "msg/Pose.msg")
+add_executable(turtlesim_square_move src/SquareMove.cpp)
 
-rosidl_get_typesupport_target(cpp_typesupport_target "${PROJECT_NAME}" "rosidl_typesupport_cpp")
+ament_target_dependencies(turtlesim_square_move "ament_index_cpp" "geometry_msgs" "rclcpp" "std_msgs" "std_srvs" "turtlesim")
 
-add_executable(square_move src/SquareMove.cpp)
+target_link_libraries(turtlesim_square_move "${cpp_typesupport_target}")
 
-ament_target_dependencies(square_move "ament_index_cpp" "geometry_msgs" "rclcpp" "std_msgs" "std_srvs")
-
-target_link_libraries(square_move "${cpp_typesupport_target}")
-
-install(TARGETS square_move
+install(TARGETS turtlesim_square_move
   DESTINATION lib/${PROJECT_NAME})
 
 ament_package()

--- a/code/turtlesim/msg/Pose.msg
+++ b/code/turtlesim/msg/Pose.msg
@@ -1,6 +1,0 @@
-float32 x
-float32 y
-float32 theta
-
-float32 linear_velocity
-float32 angular_velocity

--- a/code/turtlesim/package.xml
+++ b/code/turtlesim/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
-  <name>turtlesim_square_move</name>
+  <name>docs_turtlesim</name>
   <version>1.4.2</version>
   <description>
     turtlesim is a tool made for teaching ROS and ROS packages.

--- a/code/turtlesim/package.xml
+++ b/code/turtlesim/package.xml
@@ -1,10 +1,11 @@
 <?xml version="1.0"?>
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
-  <name>turtlesim</name>
+  <name>turtlesim_square_move</name>
   <version>1.4.2</version>
   <description>
     turtlesim is a tool made for teaching ROS and ROS packages.
+    This package generates an executable to draw a square with turtlesim.
   </description>
 
   <maintainer email="raul@eprosima.com">Raúl Sánchez-Mateos</maintainer>
@@ -12,10 +13,6 @@
   <license>BSD</license>
   <license file="LICENSE">Apache 2.0</license>
 
-  <author email="dthomas@osrfoundation.org">Dirk Thomas</author>
-  <author>Josh Faust</author>
-  <author email="mabel@openrobotics.org">Mabel Zhang</author>
-  <author email="sloretz@openrobotics.org">Shane Loretz</author>
   <author email="raul@eprosima.com">Raúl Sánchez-Mateos</author>
 
   <buildtool_depend>ament_cmake</buildtool_depend>

--- a/code/turtlesim/package.xml
+++ b/code/turtlesim/package.xml
@@ -13,6 +13,10 @@
   <license>BSD</license>
   <license file="LICENSE">Apache 2.0</license>
 
+  <author email="dthomas@osrfoundation.org">Dirk Thomas</author>
+  <author>Josh Faust</author>
+  <author email="mabel@openrobotics.org">Mabel Zhang</author>
+  <author email="sloretz@openrobotics.org">Shane Loretz</author>
   <author email="raul@eprosima.com">Raúl Sánchez-Mateos</author>
 
   <buildtool_depend>ament_cmake</buildtool_depend>

--- a/code/turtlesim/src/SquareMove.cpp
+++ b/code/turtlesim/src/SquareMove.cpp
@@ -1,5 +1,5 @@
 #include <rclcpp/rclcpp.hpp>
-#include <turtlesim/msg/pose.hpp>
+#include <turtlesim_square_move/msg/pose.hpp>
 #include <geometry_msgs/msg/twist.hpp>
 #include <std_srvs/srv/empty.hpp>
 #include <math.h>
@@ -17,7 +17,7 @@ public:
         , first_goal_set_(false)
     {
         // Create subscription on the turtle1/pose topic to keep track of the turtle pose
-        pose_subscription_ = this->create_subscription<turtlesim::msg::Pose>(
+        pose_subscription_ = this->create_subscription<turtlesim_square_move::msg::Pose>(
             "turtle1/pose",
             1, std::bind(&SquareMove::pose_callback_, this, std::placeholders::_1));
 
@@ -43,7 +43,7 @@ private:
     };
 
     void pose_callback_(
-            const turtlesim::msg::Pose& pose)
+            const turtlesim_square_move::msg::Pose& pose)
     {
         // Update the turtle pose
         pose_ = pose;
@@ -212,16 +212,16 @@ private:
     // Set the firts goal of the turtle
     bool first_goal_set_;
     // Current pose of the turtle
-    turtlesim::msg::Pose pose_;
+    turtlesim_square_move::msg::Pose pose_;
     // Current goal of the turtle
-    turtlesim::msg::Pose goal_;
+    turtlesim_square_move::msg::Pose goal_;
 
     // Timer to check the goal and perform some actions
     rclcpp::TimerBase::SharedPtr timer_;
     // Publisher in the Twist topic
     rclcpp::Publisher<geometry_msgs::msg::Twist>::SharedPtr twist_publisher_;
     // Subscription on the turtle pose topic
-    rclcpp::Subscription<turtlesim::msg::Pose>::SharedPtr pose_subscription_;
+    rclcpp::Subscription<turtlesim_square_move::msg::Pose>::SharedPtr pose_subscription_;
     // Client to reset the state of the turtlesim_node
     rclcpp::Client<std_srvs::srv::Empty>::SharedPtr reset_client_;
 };

--- a/code/turtlesim/src/SquareMove.cpp
+++ b/code/turtlesim/src/SquareMove.cpp
@@ -1,5 +1,5 @@
 #include <rclcpp/rclcpp.hpp>
-#include <turtlesim_square_move/msg/pose.hpp>
+#include <turtlesim/msg/pose.hpp>
 #include <geometry_msgs/msg/twist.hpp>
 #include <std_srvs/srv/empty.hpp>
 #include <math.h>
@@ -17,7 +17,7 @@ public:
         , first_goal_set_(false)
     {
         // Create subscription on the turtle1/pose topic to keep track of the turtle pose
-        pose_subscription_ = this->create_subscription<turtlesim_square_move::msg::Pose>(
+        pose_subscription_ = this->create_subscription<turtlesim::msg::Pose>(
             "turtle1/pose",
             1, std::bind(&SquareMove::pose_callback_, this, std::placeholders::_1));
 
@@ -43,7 +43,7 @@ private:
     };
 
     void pose_callback_(
-            const turtlesim_square_move::msg::Pose& pose)
+            const turtlesim::msg::Pose& pose)
     {
         // Update the turtle pose
         pose_ = pose;
@@ -212,16 +212,16 @@ private:
     // Set the firts goal of the turtle
     bool first_goal_set_;
     // Current pose of the turtle
-    turtlesim_square_move::msg::Pose pose_;
+    turtlesim::msg::Pose pose_;
     // Current goal of the turtle
-    turtlesim_square_move::msg::Pose goal_;
+    turtlesim::msg::Pose goal_;
 
     // Timer to check the goal and perform some actions
     rclcpp::TimerBase::SharedPtr timer_;
     // Publisher in the Twist topic
     rclcpp::Publisher<geometry_msgs::msg::Twist>::SharedPtr twist_publisher_;
     // Subscription on the turtle pose topic
-    rclcpp::Subscription<turtlesim_square_move::msg::Pose>::SharedPtr pose_subscription_;
+    rclcpp::Subscription<turtlesim::msg::Pose>::SharedPtr pose_subscription_;
     // Client to reset the state of the turtlesim_node
     rclcpp::Client<std_srvs::srv::Empty>::SharedPtr reset_client_;
 };

--- a/docs/rst/tutorials/cloud/edge_edge_repeater_cloud/edge_edge_repeater_cloud.rst
+++ b/docs/rst/tutorials/cloud/edge_edge_repeater_cloud/edge_edge_repeater_cloud.rst
@@ -190,10 +190,10 @@ Now, run the DDS Router with the configuration file created as an argument.
 Deployment of LAN 2
 -------------------
 
-Running the turtlesim_square_move on Edge 2
+Running the square_move on Edge 2
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Run the ``turtlesim_square_move`` in the Edge 2 machine, which is the controller of the Edge 1 ``turtlesim_node``.
+Run the ``square_move`` in the Edge 2 machine, which is the controller of the Edge 1 ``turtlesim_node``.
 This will send commands to the ROS 2 application to the edge to move the turtle and receive information about the current state of the turtle at any time.
 
 A ROS 2 application that moves the turtle by drawing a square has been developed for this purpose.
@@ -209,7 +209,7 @@ Then, start by creating the workspace of this application and downloading the so
     rm -rf vulcanexus
     cd ..
 
-Once created the workspace, source the Vulcanexus environment and build the ``turtlesim_square_move`` application.
+Once created the workspace, source the Vulcanexus environment and build the ``square_move`` application.
 
 .. code-block:: bash
 
@@ -235,13 +235,13 @@ And finally, run the application:
 
         .. code-block:: bash
 
-            ros2 run turtlesim turtlesim_square_move
+            ros2 run docs_turtlesim square_move
 
     .. tab:: LAN
 
         .. code-block:: bash
 
-            ROS_DOMAIN_ID=1 ros2 run turtlesim turtlesim_square_move
+            ROS_DOMAIN_ID=1 ros2 run docs_turtlesim square_move
 
         .. note::
 
@@ -280,7 +280,7 @@ The following snippet shows a configuration file (changing Domain for LAN scenar
 
         .. note::
 
-            As stated :ref:`here <warning_lan_edge_edge>`, set the ROS 2 Domain Id on the ``local`` participant in order to discover the ``turtlesim_square_move`` ROS 2 node.
+            As stated :ref:`here <warning_lan_edge_edge>`, set the ROS 2 Domain Id on the ``local`` participant in order to discover the ``square_move`` ROS 2 node.
 
 
 Now, run the DDS Router with the configuration file created as an argument.
@@ -331,18 +331,18 @@ If all the steps in this tutorial have been followed, the turtle in the ``turtle
    :scale: 75%
    :align: center
 
-and the ``turtlesim_square_move`` should prompt the following traces
+and the ``square_move`` should prompt the following traces
 
 .. code-block:: bash
 
-    root@dbf79a437eb3:/turtlesim_move_ws# ros2 run turtlesim turtlesim_square_move
-    [INFO] [1657870899.585667136] [turtlesim_square_move]: New goal [7.544445 5.544445, 0.000000]
-    [INFO] [1657870901.585656311] [turtlesim_square_move]: Reached goal
-    [INFO] [1657870901.585767260] [turtlesim_square_move]: New goal [7.448444 5.544445, 1.570796]
-    [INFO] [1657870905.685637930] [turtlesim_square_move]: Reached goal
-    [INFO] [1657870905.685753714] [turtlesim_square_move]: New goal [7.466837 7.544360, 1.561600]
-    [INFO] [1657870907.885655744] [turtlesim_square_move]: Reached goal
-    [INFO] [1657870907.885742857] [turtlesim_square_move]: New goal [7.466837 7.544360, 3.132396]
-    [INFO] [1657870911.985655175] [turtlesim_square_move]: Reached goal
-    [INFO] [1657870911.985738726] [turtlesim_square_move]: New goal [5.467175 7.581143, 3.123200]
-    [INFO] [1657870914.085652821] [turtlesim_square_move]: Reached goal
+    root@dbf79a437eb3:/turtlesim_move_ws# ros2 run turtlesim square_move
+    [INFO] [1657870899.585667136] [square_move]: New goal [7.544445 5.544445, 0.000000]
+    [INFO] [1657870901.585656311] [square_move]: Reached goal
+    [INFO] [1657870901.585767260] [square_move]: New goal [7.448444 5.544445, 1.570796]
+    [INFO] [1657870905.685637930] [square_move]: Reached goal
+    [INFO] [1657870905.685753714] [square_move]: New goal [7.466837 7.544360, 1.561600]
+    [INFO] [1657870907.885655744] [square_move]: Reached goal
+    [INFO] [1657870907.885742857] [square_move]: New goal [7.466837 7.544360, 3.132396]
+    [INFO] [1657870911.985655175] [square_move]: Reached goal
+    [INFO] [1657870911.985738726] [square_move]: New goal [5.467175 7.581143, 3.123200]
+    [INFO] [1657870914.085652821] [square_move]: Reached goal

--- a/docs/rst/tutorials/cloud/edge_edge_repeater_cloud/edge_edge_repeater_cloud.rst
+++ b/docs/rst/tutorials/cloud/edge_edge_repeater_cloud/edge_edge_repeater_cloud.rst
@@ -190,10 +190,10 @@ Now, run the DDS Router with the configuration file created as an argument.
 Deployment of LAN 2
 -------------------
 
-Running the square_move on Edge 2
+Running the turtlesim_square_move on Edge 2
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Run the ``square_move`` in the Edge 2 machine, which is the controller of the Edge 1 ``turtlesim_node``.
+Run the ``turtlesim_square_move`` in the Edge 2 machine, which is the controller of the Edge 1 ``turtlesim_node``.
 This will send commands to the ROS 2 application to the edge to move the turtle and receive information about the current state of the turtle at any time.
 
 A ROS 2 application that moves the turtle by drawing a square has been developed for this purpose.
@@ -209,7 +209,7 @@ Then, start by creating the workspace of this application and downloading the so
     rm -rf vulcanexus
     cd ..
 
-Once created the workspace, source the Vulcanexus environment and build the ``square_move`` application.
+Once created the workspace, source the Vulcanexus environment and build the ``turtlesim_square_move`` application.
 
 .. code-block:: bash
 
@@ -235,13 +235,13 @@ And finally, run the application:
 
         .. code-block:: bash
 
-            ros2 run docs_turtlesim square_move
+            ros2 run docs_turtlesim turtlesim_square_move
 
     .. tab:: LAN
 
         .. code-block:: bash
 
-            ROS_DOMAIN_ID=1 ros2 run docs_turtlesim square_move
+            ROS_DOMAIN_ID=1 ros2 run docs_turtlesim turtlesim_square_move
 
         .. note::
 
@@ -280,7 +280,7 @@ The following snippet shows a configuration file (changing Domain for LAN scenar
 
         .. note::
 
-            As stated :ref:`here <warning_lan_edge_edge>`, set the ROS 2 Domain Id on the ``local`` participant in order to discover the ``square_move`` ROS 2 node.
+            As stated :ref:`here <warning_lan_edge_edge>`, set the ROS 2 Domain Id on the ``local`` participant in order to discover the ``turtlesim_square_move`` ROS 2 node.
 
 
 Now, run the DDS Router with the configuration file created as an argument.
@@ -331,18 +331,18 @@ If all the steps in this tutorial have been followed, the turtle in the ``turtle
    :scale: 75%
    :align: center
 
-and the ``square_move`` should prompt the following traces
+and the ``turtlesim_square_move`` should prompt the following traces
 
 .. code-block:: bash
 
-    root@dbf79a437eb3:/turtlesim_move_ws# ros2 run turtlesim square_move
-    [INFO] [1657870899.585667136] [square_move]: New goal [7.544445 5.544445, 0.000000]
-    [INFO] [1657870901.585656311] [square_move]: Reached goal
-    [INFO] [1657870901.585767260] [square_move]: New goal [7.448444 5.544445, 1.570796]
-    [INFO] [1657870905.685637930] [square_move]: Reached goal
-    [INFO] [1657870905.685753714] [square_move]: New goal [7.466837 7.544360, 1.561600]
-    [INFO] [1657870907.885655744] [square_move]: Reached goal
-    [INFO] [1657870907.885742857] [square_move]: New goal [7.466837 7.544360, 3.132396]
-    [INFO] [1657870911.985655175] [square_move]: Reached goal
-    [INFO] [1657870911.985738726] [square_move]: New goal [5.467175 7.581143, 3.123200]
-    [INFO] [1657870914.085652821] [square_move]: Reached goal
+    root@dbf79a437eb3:/turtlesim_move_ws# ros2 run turtlesim turtlesim_square_move
+    [INFO] [1657870899.585667136] [turtlesim_square_move]: New goal [7.544445 5.544445, 0.000000]
+    [INFO] [1657870901.585656311] [turtlesim_square_move]: Reached goal
+    [INFO] [1657870901.585767260] [turtlesim_square_move]: New goal [7.448444 5.544445, 1.570796]
+    [INFO] [1657870905.685637930] [turtlesim_square_move]: Reached goal
+    [INFO] [1657870905.685753714] [turtlesim_square_move]: New goal [7.466837 7.544360, 1.561600]
+    [INFO] [1657870907.885655744] [turtlesim_square_move]: Reached goal
+    [INFO] [1657870907.885742857] [turtlesim_square_move]: New goal [7.466837 7.544360, 3.132396]
+    [INFO] [1657870911.985655175] [turtlesim_square_move]: Reached goal
+    [INFO] [1657870911.985738726] [turtlesim_square_move]: New goal [5.467175 7.581143, 3.123200]
+    [INFO] [1657870914.085652821] [turtlesim_square_move]: Reached goal


### PR DESCRIPTION
There is an error when vulcanexus docs is in same colcon workspace as ROS2, as there are 2 turtlesim packages.
Change package and project name of the docs project

Signed-off-by: jparisu <javierparis@eprosima.com>