### PR TITLE
Version 2.1.0 release

### DIFF
--- a/docs/rst/notes/humble/notes.rst
+++ b/docs/rst/notes/humble/notes.rst
@@ -3,7 +3,7 @@
 Humble Hierro
 =============
 
-Humble Hierro (v2.0.5)
+Humble Hierro (v2.1.0)
 ----------------------
 
 This version ships the following packages:
@@ -15,17 +15,17 @@ This version ships the following packages:
       - Package version
       - Since Vulcanexus version
     * - eProsima Fast CDR
-      - `v1.0.25 <https://github.com/eProsima/Fast-CDR/releases/tag/v1.0.25>`__
-      - v2.0.4
+      - `v1.0.26 <https://github.com/eProsima/Fast-CDR/releases/tag/v1.0.26>`__
+      - v2.1.0
     * - eProsima Fast DDS
-      - `v2.8.1 <https://fast-dds.docs.eprosima.com/en/latest/notes/notes.html#version-2-8-1>`__
-      - v2.0.5
+      - `v2.9.0 <https://fast-dds.docs.eprosima.com/en/latest/notes/notes.html#version-2-9-0>`__
+      - v2.1.0
     * - eProsima Fast DDS Gen
-      - `v2.2.0 <https://github.com/eProsima/Fast-DDS-Gen/releases/tag/v2.2.0>`__
-      - v2.0.4
+      - `v2.3.0 <https://github.com/eProsima/Fast-DDS-Gen/releases/tag/v2.3.0>`__
+      - v2.1.0
     * - foonathan_memory_vendor
-      - `v1.2.1 <https://github.com/eProsima/foonathan_memory_vendor/releases/tag/v1.2.1>`__
-      - v2.0.0
+      - `v1.2.2 <https://github.com/eProsima/foonathan_memory_vendor/releases/tag/v1.2.2>`__
+      - v2.1.0
     * - micro-ROS Agent
       - `v3.0.4 <https://github.com/micro-ROS/micro-ROS-Agent/blob/humble/micro_ros_agent/CHANGELOG.rst#304-2022-09-28>`__
       - v2.0.4
@@ -33,14 +33,14 @@ This version ships the following packages:
       - `v3.1.2 <https://github.com/micro-ROS/micro_ros_setup/blob/humble/CHANGELOG.rst#312-2022-09-28>`__
       - v2.0.4
     * - ROS 2 Monitor
-      - `v1.2.1 <https://fast-dds-monitor.readthedocs.io/en/latest/rst/notes/notes.html#version-v1-2-1>`__
-      - v2.0.4
+      - `v1.3.0 <https://fast-dds-monitor.readthedocs.io/en/latest/rst/notes/notes.html#version-v1-3-0>`__
+      - v2.1.0
     * - ROS 2 Router
-      - `v1.0.0 <https://eprosima-dds-router.readthedocs.io/en/latest/rst/notes/notes.html#version-v1-0-0>`__
-      - v2.0.4
+      - `v1.1.0 <https://eprosima-dds-router.readthedocs.io/en/latest/rst/notes/notes.html#version-v1-1-0>`__
+      - v2.1.0
     * - ROS 2 Shapes Demo
-      - `v2.8.1 <https://eprosima-shapes-demo.readthedocs.io/en/latest/notes/notes.html#version-2-8-1>`__
-      - v2.0.5
+      - `v2.9.0 <https://eprosima-shapes-demo.readthedocs.io/en/latest/notes/notes.html#version-2-9-0>`__
+      - v2.1.0
     * - ROS 2 Statistics Backend
       - `v0.8.0 <https://fast-dds-statistics-backend.readthedocs.io/en/latest/rst/notes/notes.html#version-0-8-0>`__
       - v2.0.5
@@ -48,12 +48,13 @@ This version ships the following packages:
       - `vulcanexus-humble <https://github.com/eProsima/rmw_fastrtps/tree/vulcanexus-humble>`__
       - v2.0.3
     * - eProsima Dev Utils
-      - `v0.1.0 <https://github.com/eProsima/dev-utils/releases/tag/v0.1.0>`__
-      - v2.0.4
+      - `v0.2.0 <https://github.com/eProsima/dev-utils/releases/tag/v0.2.0>`__
+      - v2.1.0
 
 Humble Hierro previous versions
 -------------------------------
 
+.. include:: previous_versions/v2.0.5.rst
 .. include:: previous_versions/v2.0.4.rst
 .. include:: previous_versions/v2.0.3.rst
 .. include:: previous_versions/v2.0.2.rst

--- a/docs/rst/notes/humble/previous_versions/v2.0.5.rst
+++ b/docs/rst/notes/humble/previous_versions/v2.0.5.rst
@@ -1,0 +1,47 @@
+Humble Hierro (v2.0.5)
+^^^^^^^^^^^^^^^^^^^^^^
+
+This version ships the following packages:
+
+.. list-table::
+    :header-rows: 1
+
+    * - Package name
+      - Package version
+      - Since Vulcanexus version
+    * - eProsima Fast CDR
+      - `v1.0.25 <https://github.com/eProsima/Fast-CDR/releases/tag/v1.0.25>`__
+      - v2.0.4
+    * - eProsima Fast DDS
+      - `v2.8.1 <https://fast-dds.docs.eprosima.com/en/latest/notes/notes.html#version-2-8-1>`__
+      - v2.0.5
+    * - eProsima Fast DDS Gen
+      - `v2.2.0 <https://github.com/eProsima/Fast-DDS-Gen/releases/tag/v2.2.0>`__
+      - v2.0.4
+    * - foonathan_memory_vendor
+      - `v1.2.1 <https://github.com/eProsima/foonathan_memory_vendor/releases/tag/v1.2.1>`__
+      - v2.0.0
+    * - micro-ROS Agent
+      - `v3.0.4 <https://github.com/micro-ROS/micro-ROS-Agent/blob/humble/micro_ros_agent/CHANGELOG.rst#304-2022-09-28>`__
+      - v2.0.4
+    * - micro-ROS Setup
+      - `v3.1.2 <https://github.com/micro-ROS/micro_ros_setup/blob/humble/CHANGELOG.rst#312-2022-09-28>`__
+      - v2.0.4
+    * - ROS 2 Monitor
+      - `v1.2.1 <https://fast-dds-monitor.readthedocs.io/en/latest/rst/notes/notes.html#version-v1-2-1>`__
+      - v2.0.4
+    * - ROS 2 Router
+      - `v1.0.0 <https://eprosima-dds-router.readthedocs.io/en/latest/rst/notes/notes.html#version-v1-0-0>`__
+      - v2.0.4
+    * - ROS 2 Shapes Demo
+      - `v2.8.1 <https://eprosima-shapes-demo.readthedocs.io/en/latest/notes/notes.html#version-2-8-1>`__
+      - v2.0.5
+    * - ROS 2 Statistics Backend
+      - `v0.8.0 <https://fast-dds-statistics-backend.readthedocs.io/en/latest/rst/notes/notes.html#version-0-8-0>`__
+      - v2.0.5
+    * - Vulcanexus Fast DDS RMW
+      - `vulcanexus-humble <https://github.com/eProsima/rmw_fastrtps/tree/vulcanexus-humble>`__
+      - v2.0.3
+    * - eProsima Dev Utils
+      - `v0.1.0 <https://github.com/eProsima/dev-utils/releases/tag/v0.1.0>`__
+      - v2.0.4

--- a/docs/rst/spelling_wordlist.txt
+++ b/docs/rst/spelling_wordlist.txt
@@ -51,6 +51,8 @@ Nao
 NetX
 Nucleo
 NuttX
+Persistency
+persistency
 Pico
 preallocates
 prebuilt

--- a/vulcanexus.repos
+++ b/vulcanexus.repos
@@ -2,27 +2,27 @@ repositories:
   eProsima/DDS-Router:
     type: git
     url: https://github.com/eProsima/DDS-Router.git
-    version: v1.0.0  
+    version: v1.1.0  
   eProsima/dev-utils:
     type: git
     url: https://github.com/eProsima/dev-utils.git
-    version: v0.1.0
+    version: v0.2.0
   eProsima/Fast-CDR:
     type: git
     url: https://github.com/eProsima/Fast-CDR.git
-    version: v1.0.25
+    version: v1.0.26
   eProsima/Fast-DDS:
     type: git
     url: https://github.com/eProsima/Fast-DDS.git
-    version: v2.8.1
+    version: v2.9.0
   eProsima/Fast-DDS-Gen:
     type: git
     url: https://github.com/eProsima/Fast-DDS-Gen.git
-    version: v2.2.0
+    version: v2.3.0
   eProsima/Fast-DDS-Monitor:
     type: git
     url: https://github.com/eProsima/Fast-DDS-monitor.git
-    version: v1.2.1
+    version: v1.3.0
   eProsima/Fast-DDS-Python:
     type: git
     url: https://github.com/eProsima/Fast-DDS-python.git
@@ -34,7 +34,7 @@ repositories:
   eProsima/Foonathan-Memory-Vendor:
     type: git
     url: https://github.com/eProsima/foonathan_memory_vendor.git
-    version: v1.2.1
+    version: v1.2.2
   eProsima/Micro-ROS-Agent:
     type: git
     url: https://github.com/micro-ROS/micro-ROS-Agent.git
@@ -50,7 +50,7 @@ repositories:
   eProsima/Micro-XRCE-DDS-Agent:
     type: git
     url: https://github.com/eProsima/Micro-XRCE-DDS-Agent
-    version: v2.2.1
+    version: v2.3.0
   eProsima/RMW-Fast-DDS:
     type: git
     url: https://github.com/eProsima/rmw_fastrtps.git
@@ -58,7 +58,7 @@ repositories:
   eProsima/Shapes-Demo:
     type: git
     url: https://github.com/eProsima/ShapesDemo.git
-    version: v2.8.1
+    version: v2.9.0
   eProsima/Shapes-Demo-TypeSupport:
     type: git
     url: https://github.com/eProsima/ShapesDemo-TypeSupport.git
@@ -66,8 +66,8 @@ repositories:
   eProsima/Vulcanexus-Base:
     type: git
     url: https://github.com/eProsima/vulcanexus.git
-    version: v2.0.5
+    version: v2.1.0
   ros2/ROSIDL-TypeSupport-FastRTPS:
     type: git
     url: https://github.com/ros2/rosidl_typesupport_fastrtps.git
-    version: 2.4.0
+    version: 2.2.0


### PR DESCRIPTION
    Updated Dev-utils to 0.2.0
    Updated DDS Router to 1.1.0
    Updated Fast DDS to 2.9.0
    Updated Fast CDR to 1.0.26
    Updated Fast DDS-Gen to 2.3.0
    Updated Fast DDS Monitor to 1.3.0
    Updated Foonathan Memory Vendor to 1.2.2
    Updated Shapes Demo to 2.9.0

Signed-off-by: Javier Santiago <javiersantiago@eprosima.com>