### PR TITLE
[19450] Fix Linux installations from sources docs

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           submodules: 'recursive'
 

--- a/.github/workflows/install_linux_from_binaries.yaml
+++ b/.github/workflows/install_linux_from_binaries.yaml
@@ -1,0 +1,18 @@
+name: Install from binaries Ubuntu
+
+on:
+  schedule:
+    - cron: '0 0 * * *'
+
+jobs:
+  ubuntu-install-from-binaries:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: 'recursive'
+
+      - name: Install from binaries
+        run: |
+          bash docs/resources/scripts/linux_binary_installation.bash

--- a/.github/workflows/install_linux_from_sources.yaml
+++ b/.github/workflows/install_linux_from_sources.yaml
@@ -1,0 +1,18 @@
+name: Install from sources Ubuntu
+
+on:
+  schedule:
+    - cron: '0 0 * * *'
+
+jobs:
+  ubuntu-install-from-sources:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: 'recursive'
+
+      - name: Install from sources
+        run: |
+          bash docs/resources/scripts/linux_source_installation.bash

--- a/docs/resources/scripts/linux_source_installation.bash
+++ b/docs/resources/scripts/linux_source_installation.bash
@@ -101,6 +101,11 @@ rm -rf \
 wget https://raw.githubusercontent.com/eProsima/vulcanexus/iron/vulcanexus.repos
 wget https://raw.githubusercontent.com/eProsima/vulcanexus/iron/colcon.meta
 vcs import --force src < vulcanexus.repos
+
+# Avoid compilation of some documentation and demo packages
+touch src/eProsima/Fast-DDS-QoS-Profiles-Manager/docs/COLCON_IGNORE
+touch src/eProsima/Vulcanexus-Base/docs/COLCON_IGNORE
+touch src/eProsima/Vulcanexus-Base/code/COLCON_IGNORE
 ##!
 
 ##LINUX_SOURCE_VULCA_DEPS

--- a/docs/resources/scripts/linux_source_installation.bash
+++ b/docs/resources/scripts/linux_source_installation.bash
@@ -106,13 +106,17 @@ vcs import --force src < vulcanexus.repos
 ##LINUX_SOURCE_VULCA_DEPS
 sudo apt update && sudo apt install -y \
     libasio-dev \
+    libdocopt-dev \
     libengine-pkcs11-openssl \
     liblog4cxx-dev \
+    liblz4-dev \
     libp11-dev \
     libqt5charts5-dev \
     libssl-dev \
     libtinyxml2-dev \
+    libxerces-c-dev \
     libyaml-cpp-dev \
+    libzstd-dev \
     openjdk-8-jdk \
     python3-sphinx \
     python3-sphinx-rtd-theme \

--- a/docs/resources/scripts/linux_source_installation.bash
+++ b/docs/resources/scripts/linux_source_installation.bash
@@ -89,8 +89,14 @@ rosdep install --from-paths src --ignore-src -y --skip-keys "fastcdr rti-connext
 ##LINUX_SOURCE_CLONE_VULCA
 cd ~
 cd vulcanexus_iron
+
 # Remove ROS 2 packages overridden by Vulcanexus
-rm -rf src/ros2/rosidl_typesupport_fastrtps/ src/eProsima/foonathan_memory_vendor/ src/ros2/rmw_fastrtps/
+rm -rf \
+    src/eProsima/foonathan_memory_vendor/ \
+    src/ros2/rosidl_typesupport_fastrtps/ \
+    src/ros2/rosidl_dynamic_typesupport_fastrtps \
+    src/ros2/rmw_fastrtps/
+
 # Get Vulcanexus sources
 wget https://raw.githubusercontent.com/eProsima/vulcanexus/iron/vulcanexus.repos
 wget https://raw.githubusercontent.com/eProsima/vulcanexus/iron/colcon.meta


### PR DESCRIPTION
The Linux installation from sources documentation was missing some dependencies, was not correctly overriding some ROS 2 packages, and was trying to compile unnecessary docs projects. This PR fixes those issues and also adds 2 workflows to check the installation methods (sources and binaries) nightly to avoid problems in the future.

To test the PR locally run `bash docs/resources/scripts/linux_source_installation.bash`. I recommend doing so within a Ubuntu 22.04 docker container to avoid installation of apt packages on the host machine.