### PR TITLE
Remove ROS 2 duplicated packages in installation from sources script

### DIFF
--- a/docs/resources/scripts/linux_source_installation.bash
+++ b/docs/resources/scripts/linux_source_installation.bash
@@ -95,7 +95,22 @@ rm -rf \
     src/eProsima/foonathan_memory_vendor/ \
     src/ros2/rosidl_typesupport_fastrtps/ \
     src/ros2/rosidl_dynamic_typesupport_fastrtps \
-    src/ros2/rmw_fastrtps/
+    src/ros2/rmw_fastrtps/ \
+    src/ros2/rosidl/rosidl_adapter/ \
+    src/ros2/rosidl/rosidl_cli/ \
+    src/ros2/rosidl/rosidl_cmake/ \
+    src/ros2/rosidl/rosidl_generator_c/ \
+    src/ros2/rosidl/rosidl_generator_cpp/ \
+    src/ros2/rosidl/rosidl_generator_tests/ \
+    src/ros2/rosidl/rosidl_generator_type_description/ \
+    src/ros2/rosidl/rosidl_parser/ \
+    src/ros2/rosidl/rosidl_pycommon/ \
+    src/ros2/rosidl/rosidl_runtime_c/ \
+    src/ros2/rosidl/rosidl_runtime_cpp/ \
+    src/ros2/rosidl/rosidl_typesupport_interface/ \
+    src/ros2/rosidl/rosidl_typesupport_introspection_c/ \
+    src/ros2/rosidl/rosidl_typesupport_introspection_cpp/ \
+    src/ros2/rosidl/rosidl_typesupport_introspection_tests/
 
 # Get Vulcanexus sources
 wget https://raw.githubusercontent.com/eProsima/vulcanexus/iron/vulcanexus.repos


### PR DESCRIPTION
This PR should fix [this failing build](https://github.com/eProsima/vulcanexus/actions/runs/8654784952).