### PR TITLE
[21590] Add documentation for the new Fast DDS 3.0 support

### DIFF
--- a/docs/rst/enhancements/fastdds3/fastdds3.rst
+++ b/docs/rst/enhancements/fastdds3/fastdds3.rst
@@ -1,0 +1,38 @@
+.. _fastdds3:
+
+Support for Fast DDS 3.0
+========================
+
+Vulcanexus now includes support for the new `Fast DDS major version 3 <https://fast-dds.docs.eprosima.com/en/latest/notes/notes.html>`, the latest version of the Data Distribution Service (DDS) implementation from eProsima.
+Fast DDS 3.0.0 introduces a range of improvements that align with Vulcanexus's mission to provide seamless and efficient middleware solutions for robotics, automotive, aerospace, and other high-demand industries.
+
+Most relevant features
+^^^^^^^^^^^^^^^^^^^^^^
+
+  Fast DDS *3.0.0* comes with significant changes and improvements, such as:
+
+   * Dynamic Language Binding API according to OMG XTypes v1.3 specification.
+   * RTPS layer APIs refactor.
+   * Extended XML configurations (e.g FlowControllers).
+   * Improvements on creation of RTPS messages.
+   * Public API and namespace update.
+   * Project renamed to `fastdds`.
+   * Refactored examples.
+   * Removed deprecated fastrtps-related api.
+   * Further improvements can be found in `Fast DDS v3.0.0 <https://github.com/eProsima/Fast-DDS/releases/tag/v3.0.0>`.
+
+Implications
+^^^^^^^^^^^^
+
+The following considerations have to be taken into account when using Vulcanexus with Fast DDS 3.0:
+
+* Communicating Vulcanexus with Fast DDS native applications:
+
+  * Update Fast DDS version to 3.0.0 or higher.
+    You can refer to our `Migration guide <https://github.com/eProsima/Fast-DDS/blob/master/UPGRADING.md>` for more detailed information.
+  * When generating types, the minimum required version of ``Fast DDS-Gen`` is ``v4.0.0``.
+    If this version is used, the extensibility  must be explicitly marked as ``@extensibility(FINAL)`` in idl structs.
+    However, starting from ``Fast DDS-Gen v4.0.1``, it can be left unspecified, as it will default to ``@final``.
+    Please, refer to `Fast DDS data types extensibility <https://fast-dds.docs.eprosima.com/en/latest/fastddsgen/dataTypes/dataTypes.html#extensibility>`_ for further information about type extensibility.
+
+* QoS settings for `Data Representation <https://fast-dds.docs.eprosima.com/en/latest/fastdds/dds_layer/core/policy/xtypesExtensions.html#datarepresentationqospolicy>` has to be set to `XCDR_DATA_REPRESENTATION`.

--- a/docs/rst/enhancements/fastdds3/fastdds3.rst
+++ b/docs/rst/enhancements/fastdds3/fastdds3.rst
@@ -1,7 +1,7 @@
 .. _fastdds3:
 
-Support for Fast DDS 3.0
-========================
+Support for Fast DDS v3
+=======================
 
 Vulcanexus now includes support for the new `Fast DDS major version 3 <https://fast-dds.docs.eprosima.com/en/v3.0.0/notes/notes.html>`__, the latest version of the Data Distribution Service (DDS) implementation from eProsima.
 Fast DDS *v3.0.0* introduces a range of improvements that align with Vulcanexus's mission to provide seamless and efficient middleware solutions for robotics, automotive, aerospace, and other high-demand industries.
@@ -24,7 +24,7 @@ Most relevant features
 Implications
 ^^^^^^^^^^^^
 
-The following considerations have to be taken into account when using Vulcanexus with Fast DDS 3.0:
+The following considerations have to be taken into account when using Vulcanexus with Fast DDS v3:
 
 * Communicating Vulcanexus with Fast DDS native applications:
 

--- a/docs/rst/enhancements/fastdds3/fastdds3.rst
+++ b/docs/rst/enhancements/fastdds3/fastdds3.rst
@@ -3,23 +3,23 @@
 Support for Fast DDS 3.0
 ========================
 
-Vulcanexus now includes support for the new `Fast DDS major version 3 <https://fast-dds.docs.eprosima.com/en/latest/notes/notes.html>`, the latest version of the Data Distribution Service (DDS) implementation from eProsima.
-Fast DDS 3.0.0 introduces a range of improvements that align with Vulcanexus's mission to provide seamless and efficient middleware solutions for robotics, automotive, aerospace, and other high-demand industries.
+Vulcanexus now includes support for the new `Fast DDS major version 3 <https://fast-dds.docs.eprosima.com/en/v3.0.0/notes/notes.html>`__, the latest version of the Data Distribution Service (DDS) implementation from eProsima.
+Fast DDS *v3.0.0* introduces a range of improvements that align with Vulcanexus's mission to provide seamless and efficient middleware solutions for robotics, automotive, aerospace, and other high-demand industries.
 
 Most relevant features
 ^^^^^^^^^^^^^^^^^^^^^^
 
-  Fast DDS *3.0.0* comes with significant changes and improvements, such as:
+  Fast DDS *v3.0.0* comes with significant changes and improvements, such as:
 
    * Dynamic Language Binding API according to OMG XTypes v1.3 specification.
    * RTPS layer APIs refactor.
    * Extended XML configurations (e.g FlowControllers).
    * Improvements on creation of RTPS messages.
    * Public API and namespace update.
-   * Project renamed to `fastdds`.
+   * Project renamed to ``fastdds``.
    * Refactored examples.
-   * Removed deprecated fastrtps-related api.
-   * Further improvements can be found in `Fast DDS v3.0.0 <https://github.com/eProsima/Fast-DDS/releases/tag/v3.0.0>`.
+   * Removed deprecated fastrtps-related API.
+   * Further improvements can be found in `Fast DDS v3.0.0 <https://github.com/eProsima/Fast-DDS/releases/tag/v3.0.0>`__.
 
 Implications
 ^^^^^^^^^^^^
@@ -28,11 +28,11 @@ The following considerations have to be taken into account when using Vulcanexus
 
 * Communicating Vulcanexus with Fast DDS native applications:
 
-  * Update Fast DDS version to 3.0.0 or higher.
-    You can refer to our `Migration guide <https://github.com/eProsima/Fast-DDS/blob/master/UPGRADING.md>` for more detailed information.
-  * When generating types, the minimum required version of ``Fast DDS-Gen`` is ``v4.0.0``.
-    If this version is used, the extensibility  must be explicitly marked as ``@extensibility(FINAL)`` in idl structs.
-    However, starting from ``Fast DDS-Gen v4.0.1``, it can be left unspecified, as it will default to ``@final``.
-    Please, refer to `Fast DDS data types extensibility <https://fast-dds.docs.eprosima.com/en/latest/fastddsgen/dataTypes/dataTypes.html#extensibility>`_ for further information about type extensibility.
+  * Update Fast DDS version to *v3.0.0* or higher.
+    You can refer to our `Migration guide <https://github.com/eProsima/Fast-DDS/blob/master/UPGRADING.md>`__ for more detailed information.
+  * When generating types, the minimum required version of Fast DDS-Gen is *v4.0.0*.
+    If this version is used, the extensibility must be explicitly marked as ``@extensibility(FINAL)`` in idl structs.
+    However, starting from Fast DDS-Gen *v4.0.1*, it can be left unspecified, as it will default to ``@extensibility(FINAL)``.
+    Please, refer to `Fast DDS data types extensibility <https://fast-dds.docs.eprosima.com/en/latest/fastddsgen/dataTypes/dataTypes.html#extensibility>`__ for further information about type extensibility.
 
-* QoS settings for `Data Representation <https://fast-dds.docs.eprosima.com/en/latest/fastdds/dds_layer/core/policy/xtypesExtensions.html#datarepresentationqospolicy>` has to be set to `XCDR_DATA_REPRESENTATION`.
+* QoS settings for `Data Representation <https://fast-dds.docs.eprosima.com/en/latest/fastdds/dds_layer/core/policy/xtypesExtensions.html#datarepresentationqospolicy>`__ has to be set to ``XCDR_DATA_REPRESENTATION``.

--- a/docs/rst/enhancements/fastdds3/fastdds3.rst
+++ b/docs/rst/enhancements/fastdds3/fastdds3.rst
@@ -32,7 +32,7 @@ The following considerations have to be taken into account when using Vulcanexus
     You can refer to our `Migration guide <https://github.com/eProsima/Fast-DDS/blob/master/UPGRADING.md>`__ for more detailed information.
   * When generating types, the minimum required version of Fast DDS-Gen is *v4.0.0*.
     If this version is used, the extensibility must be explicitly marked as ``@extensibility(FINAL)`` in idl structs.
-    However, starting from Fast DDS-Gen *v4.0.1*, it can be left unspecified, as it will default to ``@extensibility(FINAL)``.
+    However, starting from Fast DDS-Gen *v4.0.1*, it can be left unspecified, as it will default to ``@final``.
     Please, refer to `Fast DDS data types extensibility <https://fast-dds.docs.eprosima.com/en/latest/fastddsgen/dataTypes/dataTypes.html#extensibility>`__ for further information about type extensibility.
 
 * QoS settings for `Data Representation <https://fast-dds.docs.eprosima.com/en/latest/fastdds/dds_layer/core/policy/xtypesExtensions.html#datarepresentationqospolicy>`__ has to be set to ``XCDR_DATA_REPRESENTATION``.

--- a/docs/rst/enhancements/fastdds3/fastdds3.rst
+++ b/docs/rst/enhancements/fastdds3/fastdds3.rst
@@ -35,4 +35,4 @@ The following considerations have to be taken into account when using Vulcanexus
     However, starting from Fast DDS-Gen *v4.0.1*, it can be left unspecified, as it will default to ``@final``.
     Please, refer to `Fast DDS data types extensibility <https://fast-dds.docs.eprosima.com/en/latest/fastddsgen/dataTypes/dataTypes.html#extensibility>`__ for further information about type extensibility.
 
-* QoS settings for `Data Representation <https://fast-dds.docs.eprosima.com/en/latest/fastdds/dds_layer/core/policy/xtypesExtensions.html#datarepresentationqospolicy>`__ has to be set to ``XCDR_DATA_REPRESENTATION``.
+* Make sure that the QoS setting for `Data Representation <https://fast-dds.docs.eprosima.com/en/latest/fastdds/dds_layer/core/policy/xtypesExtensions.html#datarepresentationqospolicy>`__ is set to ``XCDR_DATA_REPRESENTATION``.

--- a/docs/rst/enhancements/intro.rst
+++ b/docs/rst/enhancements/intro.rst
@@ -9,4 +9,5 @@ Vulcanexus Enhancements
 .. toctree::
    :maxdepth: 1
 
+   fastdds3/fastdds3.rst
    keys/topic-keys.rst

--- a/docs/rst/tutorials/core/deployment/dds2vulcanexus/dds2vulcanexus_topic.rst
+++ b/docs/rst/tutorials/core/deployment/dds2vulcanexus/dds2vulcanexus_topic.rst
@@ -89,6 +89,12 @@ For a complete correspondence matrix between ``msg`` and ``IDL`` types (referred
 This tutorial leverages ROS 2 capabilities of describing types in ``IDL`` to define a `HelloWorld.idl` that will be used by both the Vulcanexus and native Fast DDS applications.
 The `HelloWorld.idl`, and its ``msg`` equivalent is as follows:
 
+.. important::
+
+    If generating the type for a Fast DDS native application with ``Fast DDS-Gen v4.0.0`` (the minimum required for Fast DDS *v3.0.0*), the extensibility  must be explicitly marked as ``@extensibility(FINAL)`` in idl structs.
+    Starting from ``Fast DDS-Gen v4.0.1``, it can be left unspecified, as it defaults to ``@final``.
+    Please, refer to `Fast DDS data types extensibility <https://fast-dds.docs.eprosima.com/en/latest/fastddsgen/dataTypes/dataTypes.html#extensibility>`_ for further information about type extensibility.
+
 .. tabs::
 
   .. tab:: HelloWorld.idl
@@ -213,6 +219,12 @@ In particular, the type generation related code is:
 .. literalinclude:: /resources/tutorials/core/deployment/dds2vulcanexus/topic/CMakeLists.txt
     :language: CMake
     :lines: 65-82
+
+.. important::
+
+    If generating the type for a Fast DDS native application with ``Fast DDS-Gen v4.0.0`` (the minimum required for Fast DDS *v3.0.0*), the extensibility  must be explicitly marked as ``@extensibility(FINAL)`` in idl structs.
+    Starting from ``Fast DDS-Gen v4.0.1``, it can be left unspecified, as it defaults to ``@final``.
+    Please, refer to `Fast DDS data types extensibility <https://fast-dds.docs.eprosima.com/en/latest/fastddsgen/dataTypes/dataTypes.html#extensibility>`_ for further information about type extensibility.
 
 The call to *Fast DDS-Gen* within ``add_custom_command`` will generate the type support in the `fastdds_app` directory, leaving the file names in a convenient ``GENERATED_TYPE_SUPPORT_FILES`` CMake variable that is later used to add the source files to the executable.
 It is important to note the *Fast DDS-Gen* is called with the `-typeros2` flag, so it generates ROS 2 compatible type names.

--- a/docs/rst/tutorials/core/deployment/dds2vulcanexus/dds2vulcanexus_topic.rst
+++ b/docs/rst/tutorials/core/deployment/dds2vulcanexus/dds2vulcanexus_topic.rst
@@ -92,7 +92,7 @@ The `HelloWorld.idl`, and its ``msg`` equivalent is as follows:
 .. important::
 
     If generating the type for a Fast DDS native application with Fast DDS-Gen *v4.0.0* (the minimum required for Fast DDS *v3.0.0*), the extensibility  must be explicitly marked as ``@extensibility(FINAL)`` in idl structs.
-    Starting from Fast DDS-Gen *v4.0.1*, it can be left unspecified, as it defaults to ``@extensibility(FINAL)``.
+    Starting from Fast DDS-Gen *v4.0.1*, it can be left unspecified, as it defaults to ``@final``.
     Please, refer to `Fast DDS data types extensibility <https://fast-dds.docs.eprosima.com/en/latest/fastddsgen/dataTypes/dataTypes.html#extensibility>`__ for further information about type extensibility.
 
 .. tabs::
@@ -223,7 +223,7 @@ In particular, the type generation related code is:
 .. important::
 
     If generating the type for a Fast DDS native application with Fast DDS-Gen *v4.0.0* (the minimum required for Fast DDS *v3.0.0*), the extensibility  must be explicitly marked as ``@extensibility(FINAL)`` in idl structs.
-    Starting from Fast DDS-Gen *v4.0.1*, it can be left unspecified, as it defaults to ``@extensibility(FINAL)``.
+    Starting from Fast DDS-Gen *v4.0.1*, it can be left unspecified, as it defaults to ``@final``.
     Please, refer to `Fast DDS data types extensibility <https://fast-dds.docs.eprosima.com/en/latest/fastddsgen/dataTypes/dataTypes.html#extensibility>`__ for further information about type extensibility.
 
 The call to *Fast DDS-Gen* within ``add_custom_command`` will generate the type support in the `fastdds_app` directory, leaving the file names in a convenient ``GENERATED_TYPE_SUPPORT_FILES`` CMake variable that is later used to add the source files to the executable.

--- a/docs/rst/tutorials/core/deployment/dds2vulcanexus/dds2vulcanexus_topic.rst
+++ b/docs/rst/tutorials/core/deployment/dds2vulcanexus/dds2vulcanexus_topic.rst
@@ -91,9 +91,9 @@ The `HelloWorld.idl`, and its ``msg`` equivalent is as follows:
 
 .. important::
 
-    If generating the type for a Fast DDS native application with ``Fast DDS-Gen v4.0.0`` (the minimum required for Fast DDS *v3.0.0*), the extensibility  must be explicitly marked as ``@extensibility(FINAL)`` in idl structs.
-    Starting from ``Fast DDS-Gen v4.0.1``, it can be left unspecified, as it defaults to ``@final``.
-    Please, refer to `Fast DDS data types extensibility <https://fast-dds.docs.eprosima.com/en/latest/fastddsgen/dataTypes/dataTypes.html#extensibility>`_ for further information about type extensibility.
+    If generating the type for a Fast DDS native application with Fast DDS-Gen *v4.0.0* (the minimum required for Fast DDS *v3.0.0*), the extensibility  must be explicitly marked as ``@extensibility(FINAL)`` in idl structs.
+    Starting from Fast DDS-Gen *v4.0.1*, it can be left unspecified, as it defaults to ``@extensibility(FINAL)``.
+    Please, refer to `Fast DDS data types extensibility <https://fast-dds.docs.eprosima.com/en/latest/fastddsgen/dataTypes/dataTypes.html#extensibility>`__ for further information about type extensibility.
 
 .. tabs::
 
@@ -222,9 +222,9 @@ In particular, the type generation related code is:
 
 .. important::
 
-    If generating the type for a Fast DDS native application with ``Fast DDS-Gen v4.0.0`` (the minimum required for Fast DDS *v3.0.0*), the extensibility  must be explicitly marked as ``@extensibility(FINAL)`` in idl structs.
-    Starting from ``Fast DDS-Gen v4.0.1``, it can be left unspecified, as it defaults to ``@final``.
-    Please, refer to `Fast DDS data types extensibility <https://fast-dds.docs.eprosima.com/en/latest/fastddsgen/dataTypes/dataTypes.html#extensibility>`_ for further information about type extensibility.
+    If generating the type for a Fast DDS native application with Fast DDS-Gen *v4.0.0* (the minimum required for Fast DDS *v3.0.0*), the extensibility  must be explicitly marked as ``@extensibility(FINAL)`` in idl structs.
+    Starting from Fast DDS-Gen *v4.0.1*, it can be left unspecified, as it defaults to ``@extensibility(FINAL)``.
+    Please, refer to `Fast DDS data types extensibility <https://fast-dds.docs.eprosima.com/en/latest/fastddsgen/dataTypes/dataTypes.html#extensibility>`__ for further information about type extensibility.
 
 The call to *Fast DDS-Gen* within ``add_custom_command`` will generate the type support in the `fastdds_app` directory, leaving the file names in a convenient ``GENERATED_TYPE_SUPPORT_FILES`` CMake variable that is later used to add the source files to the executable.
 It is important to note the *Fast DDS-Gen* is called with the `-typeros2` flag, so it generates ROS 2 compatible type names.


### PR DESCRIPTION
This PR adds some documentation to be taken into account for the new Fast DDS v3.0.0 support starting in `Vulcanexus-Jazzy`.