### PR TITLE
[22319] Bump version to v2.7.0

### DIFF
--- a/docs/rst/notes/humble/previous_versions/v2.6.0.rst
+++ b/docs/rst/notes/humble/previous_versions/v2.6.0.rst
@@ -1,7 +1,5 @@
-.. _notes_humble_latest:
-
-Humble Hierro (v2.7.0)
-======================
+Humble Hierro (v2.6.0)
+----------------------
 
 This version ships the following packages:
 
@@ -15,14 +13,14 @@ This version ships the following packages:
       - `v1.1.1 <https://github.com/eProsima/Fast-CDR/releases/tag/v1.1.1>`__
       - v2.4.0
     * - eProsima Fast DDS
-      - `v2.14.4 <https://fast-dds.docs.eprosima.com/en/latest/notes/notes.html#version-2-14-4>`__
-      - v2.7.0
+      - `v2.14.2 <https://fast-dds.docs.eprosima.com/en/latest/notes/notes.html#version-2-14-2>`__
+      - v2.6.0
     * - eProsima Fast DDS Python
-      - `v1.4.3 <https://github.com/eProsima/Fast-DDS-python/releases/tag/v1.4.3>`__
-      - v2.7.0
+      - `v1.4.2 <https://github.com/eProsima/Fast-DDS-python/releases/tag/v1.4.2>`__
+      - v2.6.0
     * - eProsima Fast DDS Gen
-      - `v3.3.1 <https://github.com/eProsima/Fast-DDS-Gen/releases/tag/v3.3.1>`__
-      - v2.7.0
+      - `v3.3.0 <https://github.com/eProsima/Fast-DDS-Gen/releases/tag/v3.3.0>`__
+      - v2.5.0
     * - foonathan_memory_vendor
       - `v1.3.1 <https://github.com/eProsima/foonathan_memory_vendor/releases/tag/v1.3.1>`__
       - v3.0.0
@@ -48,8 +46,8 @@ This version ships the following packages:
       - `v2.2.0 <https://eprosima-dds-router.readthedocs.io/en/latest/rst/notes/notes.html#version-v2-2-0>`__
       - v2.5.0
     * - ROS 2 Shapes Demo
-      - `v2.14.4 <https://eprosima-shapes-demo.readthedocs.io/en/latest/notes/notes.html#version-2-14-4>`__
-      - v2.7.0
+      - `v2.14.2 <https://eprosima-shapes-demo.readthedocs.io/en/latest/notes/notes.html#version-2-14-2>`__
+      - v2.6.0
     * - ROS 2 Shapes Demo TypeSupport
       - `v1.0.0 <https://github.com/eProsima/ShapesDemo-TypeSupport/releases/tag/v1.0.0>`__
       - v2.4.0
@@ -57,8 +55,8 @@ This version ships the following packages:
       - `v1.1.0 <https://fast-dds-statistics-backend.readthedocs.io/en/latest/rst/notes/notes.html#version-1-1-0>`__
       - v2.5.0
     * - Vulcanexus Fast DDS RMW
-      - `v2.7.0 <https://github.com/eProsima/rmw_fastrtps/releases/tag/v2.7.0>`__
-      - v2.7.0
+      - `v2.6.0 <https://github.com/eProsima/rmw_fastrtps/releases/tag/v2.6.0>`__
+      - v2.6.0
     * - eProsima Dev Utils
       - `v0.6.0 <https://github.com/eProsima/dev-utils/releases/tag/v0.6.0>`__
       - v2.5.0
@@ -75,28 +73,11 @@ This version ships the following packages:
       - `v0.1.0 <https://fast-dds-qos-profiles-manager.readthedocs.io/en/latest/rst/notes/notes.html#version-0-1-0>`__
       - v3.0.0
     * - Vulcanexus IDL TypeSupport Fast DDS
-      - `v2.7.0 <https://github.com/eProsima/rosidl_typesupport_fastrtps/releases/tag/v2.7.0>`__
-      - v2.7.0
+      - `v2.6.0 <https://github.com/eProsima/rosidl_typesupport_fastrtps/releases/tag/v2.6.0>`__
+      - v2.6.0
     * - Vulcanexus IDL
-      - `v2.7.0 <https://github.com/eProsima/rosidl/releases/tag/v2.7.0>`__
-      - v2.7.0
+      - `v2.6.0 <https://github.com/eProsima/rosidl/releases/tag/v2.6.0>`__
+      - v2.6.0
     * - Vulcanexus Base
-      - `v2.7.0 <https://docs.vulcanexus.org/en/latest/rst/notes/iron/notes.html#humble-hierro-v2-7-0>`__
-      - v2.7.0
-
-Humble Hierro previous versions
-===============================
-
-.. include:: previous_versions/v2.6.0.rst
-.. include:: previous_versions/v2.5.0.rst
-.. include:: previous_versions/v2.4.0.rst
-.. include:: previous_versions/v2.3.0.rst
-.. include:: previous_versions/v2.2.0.rst
-.. include:: previous_versions/v2.1.1.rst
-.. include:: previous_versions/v2.1.0.rst
-.. include:: previous_versions/v2.0.5.rst
-.. include:: previous_versions/v2.0.4.rst
-.. include:: previous_versions/v2.0.3.rst
-.. include:: previous_versions/v2.0.2.rst
-.. include:: previous_versions/v2.0.1.rst
-.. include:: previous_versions/v2.0.0.rst
+      - `v2.6.0 <https://docs.vulcanexus.org/en/latest/rst/notes/humble/notes.html#humble-hierro-v2-6-0>`__
+      - v2.6.0

--- a/docs/rst/notes/notes.rst
+++ b/docs/rst/notes/notes.rst
@@ -25,7 +25,7 @@ The following table outlines the Vulcanexus releases and their support cycles:
      - Release Date
      - EOL Date
    * - :ref:`Humble Hierro <notes_humble_latest>`
-     - v2.6.0
+     - v2.7.0
      - May 2022
      - May 2027
    * - :ref:`Galactic Gamble <notes_galactic_latest>`

--- a/vulcanexus.repos
+++ b/vulcanexus.repos
@@ -26,11 +26,11 @@ repositories:
   eProsima/Fast-DDS:
     type: git
     url: https://github.com/eProsima/Fast-DDS.git
-    version: v2.14.2
+    version: v2.14.4
   eProsima/Fast-DDS-Gen:
     type: git
     url: https://github.com/eProsima/Fast-DDS-Gen.git
-    version: v3.3.0
+    version: v3.3.1
   eProsima/Fast-DDS-Monitor:
     type: git
     url: https://github.com/eProsima/Fast-DDS-monitor.git
@@ -38,7 +38,7 @@ repositories:
   eProsima/Fast-DDS-Python:
     type: git
     url: https://github.com/eProsima/Fast-DDS-python.git
-    version: v1.4.2
+    version: v1.4.3
   eProsima/Fast-DDS-QoS-Profiles-Manager:
     type: git
     url: https://github.com/eProsima/Fast-DDS-QoS-Profiles-Manager.git
@@ -74,11 +74,11 @@ repositories:
   eProsima/RMW-Fast-DDS:
     type: git
     url: https://github.com/eProsima/rmw_fastrtps.git
-    version: v2.6.0
+    version: v2.7.0
   eProsima/Shapes-Demo:
     type: git
     url: https://github.com/eProsima/ShapesDemo.git
-    version: v2.14.2
+    version: v2.14.4
   eProsima/Shapes-Demo-TypeSupport:
     type: git
     url: https://github.com/eProsima/ShapesDemo-TypeSupport.git
@@ -86,12 +86,12 @@ repositories:
   eProsima/Vulcanexus-Base:
     type: git
     url: https://github.com/eProsima/vulcanexus.git
-    version: v2.6.0
+    version: v2.7.0
   eProsima/rosidl:
     type: git
     url: https://github.com/eProsima/rosidl.git
-    version: v2.6.0
+    version: v2.7.0
   eProsima/ROSIDL-TypeSupport-FastRTPS:
     type: git
     url: https://github.com/eProsima/rosidl_typesupport_fastrtps
-    version: v2.6.0
+    version: v2.7.0

--- a/vulcanexus_base/CMakeLists.txt
+++ b/vulcanexus_base/CMakeLists.txt
@@ -16,7 +16,7 @@ cmake_minimum_required(VERSION 3.8)
 project(vulcanexus_base)
 
 set(vulcanexus_base_MAJOR_VERSION 2)
-set(vulcanexus_base_MINOR_VERSION 6)
+set(vulcanexus_base_MINOR_VERSION 7)
 set(vulcanexus_base_PATCH_VERSION 0)
 set(vulcanexus_base_MAJOR_VERSION
     ${vulcanexus_base_MAJOR_VERSION}.${vulcanexus_base_MINOR_VERSION}.${vulcanexus_base_PATCH_VERSION})


### PR DESCRIPTION
This PR bumps the project version to `v2.7.0`. 
*Note: When this PR gets merged, we need to tag the commit with `v2.7.0`*