### PR TITLE
[22721] Increase 'max_blocking_time' in Easy Mode

### DIFF
--- a/docs/rst/enhancements/easy_mode/easy_mode.rst
+++ b/docs/rst/enhancements/easy_mode/easy_mode.rst
@@ -138,7 +138,7 @@ For a practical example demo, please refer to the :ref:`easy_mode_tutorial`.
 
 .. note::
     When ``ROS2_EASY_MODE`` is enabled, Fast DDS automatically loads a custom XML profile named ``service``.
-    This profile increases the server's response timeout for ROS2 services by modifying the
+    This profile increases the server's response timeout for ROS 2 services by modifying the
     `max_blocking_time <https://fast-dds.docs.eprosima.com/en/latest/fastdds/dds_layer/core/policy/standardQosPolicies.html#reliabilityqospolicy>`_.
     However, if the user provides an XML file that already contains a profile with the same name, Fast DDS will not
     load any extra profile.

--- a/docs/rst/enhancements/easy_mode/easy_mode.rst
+++ b/docs/rst/enhancements/easy_mode/easy_mode.rst
@@ -135,3 +135,11 @@ At the same time, the right part of the figure illustrates the case of a differe
 Which is perfectly valid and can coexist with the other domain.
 
 For a practical example demo, please refer to the :ref:`easy_mode_tutorial`.
+
+.. note::
+    When ``ROS2_EASY_MODE`` is enabled, Fast DDS automatically loads a custom XML profile named ``service``.
+    This profile increases the server's response timeout for ROS2 services by modifying the
+    `max_blocking_time <https://fast-dds.docs.eprosima.com/en/latest/fastdds/dds_layer/core/policy/standardQosPolicies.html#reliabilityqospolicy>`_.
+    However, if the user provides an XML file that already contains a profile with the same name, Fast DDS will not
+    load any extra profile.
+    Instead, the `max_blocking_time <https://fast-dds.docs.eprosima.com/en/latest/fastdds/dds_layer/core/policy/standardQosPolicies.html#reliabilityqospolicy>`_ value defined in the user's XML file will be used.


### PR DESCRIPTION
This PR adds an explanatory note to detail the behavior of the `service` XML profile loaded automatically by Fast DDS (if `ROS2_EASY_MODE` is enabled) and how it will behave in case the user has its own XML profile defined.

Merge after:

- https://github.com/eProsima/Fast-DDS/pull/5617
