### PR TITLE
[23652] Bump Vulcanexus Jazzy to v4.3.2 (with HRI modules)  

### DIFF
--- a/docs/rst/notes/jazzy/notes.rst
+++ b/docs/rst/notes/jazzy/notes.rst
@@ -1,6 +1,6 @@
 .. _notes_jazzy_latest:
 
-Jazzy Jolo (v4.3.1)
+Jazzy Jolo (v4.3.2)
 ===================
 
 This version ships the following packages:
@@ -15,7 +15,7 @@ This version ships the following packages:
       - `v2.3.0 <https://github.com/eProsima/Fast-CDR/releases/tag/v2.3.0>`__
       - v4.3.0
     * - eProsima Fast DDS
-      - `v3.2.2 <https://fast-dds.docs.eprosima.com/en/3.x/notes/previous_versions/supported_versions.html>`__
+      - `v3.3.0 <https://fast-dds.docs.eprosima.com/en/3.x/notes/previous_versions/supported_versions.html>`__
       - v4.3.0
     * - eProsima Fast DDS Python
       - `v2.2.0 <https://github.com/eProsima/Fast-DDS-python/releases/tag/v2.2.0>`__
@@ -76,7 +76,7 @@ This version ships the following packages:
       - v4.1.0
     * - Vulcanexus Base
       - `v4.3.0 <https://docs.vulcanexus.org/en/latest/rst/notes/jazzy/notes.html#jazzy-imagination-v4-3-1>`__
-      - v4.3.1
+      - v4.3.2
 
 Jazzy Jolo previous versions
 ============================

--- a/docs/rst/notes/notes.rst
+++ b/docs/rst/notes/notes.rst
@@ -27,7 +27,7 @@ The following table outlines the Vulcanexus releases and their support cycles:
      - Release Date
      - EOL Date
    * - :ref:`Jazzy Jolo <notes_jazzy_latest>`
-     - v4.3.1
+     - v4.3.2
      - October 2024
      - May 2029
    * - :ref:`Iron Imagination <notes_iron_latest>`

--- a/vulcanexus.repos
+++ b/vulcanexus.repos
@@ -26,7 +26,7 @@ repositories:
   eProsima/Fast-DDS:
     type: git
     url: https://github.com/eProsima/Fast-DDS.git
-    version: v3.2.2
+    version: v3.3.0
   eProsima/Fast-DDS-Gen:
     type: git
     url: https://github.com/eProsima/Fast-DDS-Gen.git
@@ -90,8 +90,12 @@ repositories:
   eProsima/Vulcanexus:
     type: git
     url: https://github.com/eProsima/vulcanexus.git
-    version: v4.3.1
+    version: 4.3.2
   eProsima/ROSIDL-Dynamic-TypeSupport-FastRTPS:
     type: git
     url: https://github.com/eProsima/rosidl_dynamic_typesupport_fastrtps.git
     version: v4.1.0
+  eProsima/Vulcanexus-HRI:
+    type: git
+    url: https://github.com/eProsima/agile-hri.git
+    version: 4.3.2

--- a/vulcanexus_base/CMakeLists.txt
+++ b/vulcanexus_base/CMakeLists.txt
@@ -16,8 +16,8 @@ cmake_minimum_required(VERSION 3.8)
 project(vulcanexus_base)
 
 set(vulcanexus_base_MAJOR_VERSION 4)
-set(vulcanexus_base_MINOR_VERSION 2)
-set(vulcanexus_base_PATCH_VERSION 0)
+set(vulcanexus_base_MINOR_VERSION 3)
+set(vulcanexus_base_PATCH_VERSION 2)
 set(vulcanexus_base_MAJOR_VERSION
     ${vulcanexus_base_MAJOR_VERSION}.${vulcanexus_base_MINOR_VERSION}.${vulcanexus_base_PATCH_VERSION})
 


### PR DESCRIPTION
This PR Bumbs Vulcanexus Jazzy to v4.3.2, which:
- Updates Fast DDS library to v3.3.0
- Adds HRI modules as new meta-package

Related PRs:
- https://github.com/eProsima/vulcanexus-builder/pull/54
- https://github.com/eProsima/vulcanexus/pull/255